### PR TITLE
fix: add commander dep that matches commander typings dep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: npm ci
 
       - name: Run ESLint
-        run: npx nx run-many --target lint --max-warnings 0
+        run: npm run lint
 
       - name: Run Prettier
         run: npx prettier --check .

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "prettier": "@tobysmith568/prettier-config",
   "scripts": {
     "build": "npx nx run-many --target build",
-    "test": "npx nx run-many --target test"
+    "test": "npx nx run-many --target test",
+    "lint": "npx nx run-many --target lint --max-warnings 0"
   },
   "devDependencies": {
     "@astrojs/mdx": "^2.0.2",

--- a/packages/license-cop/package.json
+++ b/packages/license-cop/package.json
@@ -34,6 +34,7 @@
     "@commander-js/extra-typings": "^12.0.0",
     "@npmcli/arborist": "^7.0.0",
     "axios": "^1.6.0",
+    "commander": "^12.0.0",
     "compare-versions": "^6.0.0-rc.1",
     "cosmiconfig": "^9.0.0",
     "deepmerge": "^4.3.1",

--- a/packages/license-cop/src/index.ts
+++ b/packages/license-cop/src/index.ts
@@ -6,3 +6,16 @@ export {
   LicensedPackage,
   NoLicenseResult
 } from "./lib/result";
+
+// The following is included to insure that Nx doesn't remove "commander"
+// as a dependency from packages/license-cop/package.json.
+//
+// This is necessary because the @nx/dependency-checks eslint rule will
+// remove commander if the license-cop package never imports from it directly.
+//
+// This approach was chosen over using the ignoredDependencies config option
+// to insure that the same eslint rule continues to catch when the commander
+// version falls out of sync with the @commander-js/extra-typings version.
+import type { Command as _Command } from "commander";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _UnusedCommand = _Command;


### PR DESCRIPTION
as recommended by the [typings repo docs](https://github.com/commander-js/extra-typings?tab=readme-ov-file#extra-typings-for-commander):

> The installed version of this package should match the major and minor version numbers of the installed commander package, but the patch version number is independent (following pattern used by Definitely Typed).

in my case it ended up using a commander version that didn't match and was missing `command.hook()`