### PR TITLE
Allow bools set from config to be true even when they're false on the CLI

### DIFF
--- a/packages/license-cop/src/lib/cli/commands/main.ts
+++ b/packages/license-cop/src/lib/cli/commands/main.ts
@@ -42,8 +42,8 @@ const runLicenseCop = async (
     allowedPackages: config.packages,
 
     workingDirectory: directory,
-    includeDevDependencies: includeDevDependencies ?? config.includeDevDependencies,
-    devDependenciesOnly: devDependenciesOnly ?? config.devDependenciesOnly
+    includeDevDependencies: includeDevDependencies || config.includeDevDependencies,
+    devDependenciesOnly: devDependenciesOnly || config.devDependenciesOnly
   };
 
   const result = await checkLicenses(options);


### PR DESCRIPTION
Fixes #176